### PR TITLE
DOCKER (v2 fix + image size reduction)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,16 @@
-FROM golang:latest
+# build
+FROM golang:latest as builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
-RUN go install github.com/cosmtrek/air@latest
+RUN go install github.com/air-verse/air@latest
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -o ./bin/ghostbin ./cmd/ghostbin/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -o ./bin/ghostbin ./cmd/webapp/main.go
+
+# deploy
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+WORKDIR /app
+COPY --from=builder /app .
 EXPOSE 8080
-ENTRYPOINT ["/app/bin/ghostbin"]
+CMD ["/app/bin/ghostbin"]


### PR DESCRIPTION
Hi, you forgot to update your Dockerfile for version 2. 
I also did a multistage build, which reduced the size of the finished image from 1180 to 25 megabytes.